### PR TITLE
pv-20 Normalizar fechas en todo el sistema

### DIFF
--- a/public/assets/js/cliente.js
+++ b/public/assets/js/cliente.js
@@ -85,10 +85,10 @@ $( document ).on('change', '#cliente_modalidad', function () {
 })
 
 function _calculateAge(birthday) {
-    const dateParts = birthday.split('/'); // split the string by '/'
-    const day = parseInt(dateParts[0]); // extract the day as an integer
+    const dateParts = birthday.split('-'); // split the string by '/'
+    const day = parseInt(dateParts[2]); // extract the day as an integer
     const month = parseInt(dateParts[1]) - 1; // extract the month as an integer (subtract 1 as January is month 0)
-    const year = parseInt(dateParts[2]); // extract the year as an integer
+    const year = parseInt(dateParts[0]); // extract the year as an integer
 
     birthday = new Date(year, month, day)
     var ageDifMs = Date.now() - birthday.getTime();
@@ -123,10 +123,6 @@ $( document ).ready(function () {
     $('[data-toggle="tooltip"]').tooltip();
 
     $('#cliente_familiarResponsableAcompanante').find('.radio').addClass('form-check form-check-inline');
-
-    $('.js-datepicker').datepicker({
-        format: 'dd/mm/yyyy'
-    });
 
 });
 

--- a/public/assets/js/dashboard.js
+++ b/public/assets/js/dashboard.js
@@ -1,6 +1,3 @@
 $( document ).ready(function () {
-    $('.js-datepicker').datepicker({
-        format: 'dd/mm/yyyy',
-        language: "es",
-    });
+
 });

--- a/public/assets/js/staff.js
+++ b/public/assets/js/staff.js
@@ -226,10 +226,6 @@ if($('#doctor_modalidad').is(':visible')) {
     });
 }
 
-$('.js-datepicker').datepicker({
-    format: 'yyyy-mm-dd'
-});
-
 $('.predictivo').chosen();
 $( "#buscarContrato" ).on('click', function(){
     location.href = '?ctr=' + $('#contrato').val();

--- a/src/Controller/ClienteController.php
+++ b/src/Controller/ClienteController.php
@@ -158,13 +158,14 @@ class ClienteController extends AbstractController
             $obArray[$ob->getId()] = $ob->getNombre();
         }
 
-        $from = $request->get('from', null);
-        $to = $request->get('to', null);
-        $vto = $request->get('vto', null);
-
-        $fechaDesde = \DateTime::createFromFormat("d/m/Y", $from);
-        $fechaHasta = \DateTime::createFromFormat("d/m/Y", $to);
-        $vencimientoAut = \DateTime::createFromFormat("d/m/Y", $vto);
+        $f          = new \DateTime('first day of this month');
+        $l          = new \DateTime('last day of this month');
+        $from       = $request->get('from' , $f->format('Y-m-d'));
+        $to         = $request->get('to', $l->format('Y-m-d'));
+        $vto        = $request->get('vto');    
+        $fechaDesde = $from ? new \DateTime($from. '0:0:0') : $from;
+        $fechaHasta = $to   ? new \DateTime($to. '23:59:59'): $to;
+        $vencimientoAut = new \DateTime($vto);
 
         $clientes = $clienteRepository->findByNameDocReferentePaginado(null, $nombre, $prof, $vto, $hc, null);
         
@@ -209,25 +210,25 @@ class ClienteController extends AbstractController
 
         return $this->render('cliente/historico.html.twig',
             [
-                'obraSociales' => $obArray,
-                'historiasArray' => $historiasPaginado['results'],
-                'from' => $from,
-                'to' => $to,
-                'vto' => $vto,
-                'nombre' => $nombre,
-                'estado' => $estado,
-                'obraSocial' => $obraSocial,
-                'prof' => $prof,
-                'profesionales' => $docReferentes,
-                'modalidad' => $modalidad,
-                'hab' => $hab,
-                'total' => $historiasPaginado['total'],
+                'obraSociales'      => $obArray,
+                'historiasArray'    => $historiasPaginado['results'],
+                'from'              => $from,
+                'to'                => $to,
+                'vto'               => $vto,
+                'nombre'            => $nombre,
+                'estado'            => $estado,
+                'obraSocial'        => $obraSocial,
+                'prof'              => $prof,
+                'profesionales'     => $docReferentes,
+                'modalidad'         => $modalidad,
+                'hab'               => $hab,
+                'total'             => $historiasPaginado['total'],
                 'habitacionesArray' => $habitacionesArray,
-                'maxPages'=> $maxPages,
-                'thisPage' => $currentPage,
-                'limit' => $limit,
+                'maxPages'          => $maxPages,
+                'thisPage'          => $currentPage,
+                'limit'             => $limit,
                 'paginaImprimible' => true,
-                'hc' => $hc,
+                'hc'                => $hc,
             ]);
     }
 
@@ -380,25 +381,30 @@ class ClienteController extends AbstractController
             $obArray[$ob->getId()] = $ob->getNombre();
         }
 
-        $from = $request->get('from', false);
-        $to = $request->get('to', false);
-        $vto = $request->get('vto', null);
+        $f          = new \DateTime('first day of this month');
+        $l          = new \DateTime('last day of this month');
+        $from       = $request->get('from' , $f->format('Y-m-d'));
+        $to         = $request->get('to', $l->format('Y-m-d'));
+        $vto        = $request->get('vto');    
+        $fechaDesde = $from ? new \DateTime($from. '0:0:0') : $from;
+        $fechaHasta = $to   ? new \DateTime($to. '23:59:59'): $to;
 
-        if ( !$from ) {
-            $from = date('d/m/Y',strtotime("first day of last month"));
-        }
-        if ( !$to ) {
-            $to = date('d/m/Y',strtotime("last day of last month"));
-        }
+        $totalDia               = [];
+        $internados             = [];
+        $derivados              = [];
+        $sinModalidad           = [];
+        $ambulatorios           = [];
+        $egresos                = [];
+
+        $referentes             = [];
+        $arrayParaLaVista       = [];
+        $obrasSocialesTotales   = [];
+        $totalReferentes        = [];
+        $range                  = [];
+        $historias              = null;
 
         if($from && $to) {
-            $fechaDesde = \DateTime::createFromFormat("d/m/Y", $from);
-            $fechaHasta = \DateTime::createFromFormat("d/m/Y", $to);
-            $fechaDesde->setTime(00, 00, 00);
-            $fechaHasta->setTime(23, 59, 59);
-            $vencimientoAut = \DateTime::createFromFormat("d/m/Y", $vto);
-
-            $range = [];
+            $vencimientoAut = \DateTime::createFromFormat("d/m/Y", $vto);   
             
             if ($fechaDesde && $fechaHasta) {
                 $interval = new DateInterval("P1D");
@@ -409,23 +415,11 @@ class ClienteController extends AbstractController
                 $fechaHasta = $fechaDesde;
             }
 
-
-            $historias = $historiaPacienteRepository->getHistoricoDesdeHasta($fechaDesde->format('Y-m-d'), $fechaHasta->format('Y-m-d'), $nombre, $modalidad, $obraSocial, $prof, $hc);
+            $historias = $historiaPacienteRepository->getHistoricoDesdeHasta($fechaDesde, $fechaHasta, $nombre, $modalidad, $obraSocial, $prof, $hc);
 
             // $historiasPaginado['results'] = array_slice($historias, $limit * ($currentPage - 1), $limit);
             // $historiasPaginado['total'] = count($historias);
             // $maxPages = ceil($historiasPaginado['total'] / $limit);
-
-            $arrayParaLaVista = [];
-            $ambulatorios = [];
-            $internados = [];
-            $derivados = [];
-            $sinModalidad = [];
-            $egresos = [];
-            $totalDia = [];
-            $referentes = [];
-            $obrasSocialesTotales = [];
-            $totalReferentes = [];
 
             foreach ($historias as $historia) {
                 $cliente = $historia->getCliente();
@@ -433,15 +427,14 @@ class ClienteController extends AbstractController
                 $fechaDesde2 = (($cliente->getFIngreso() != null) && $fechaDesde2 < $cliente->getFIngreso()) ? $cliente->getFIngreso()->format('d-m-Y') : $fechaDesde2->format('d-m-Y');
                 $fechaHasta2 = (!empty ($historia->getFechaFin()) && $historia->getFechaFin() <= $fechaHasta) ? $historia->getFechaFin() : $fechaHasta;
                 $fechaHasta2 = (($cliente->getFEgreso() != null) && $fechaHasta2 > $cliente->getFEgreso()) ? $cliente->getFEgreso()->format('d-m-Y') : $fechaHasta2->format('d-m-Y');
-                $fechaDesde2 = new \DateTime($fechaDesde2);
-                $fechaHasta2 = new \DateTime($fechaHasta2);
+                $fechaDesde2 = new \DateTime($fechaDesde2. '0:0:0');
+                $fechaHasta2 = new \DateTime($fechaHasta2. '23:59:59');
                 $fechaHasta2->modify('+1 day');
 
                 $interval = new DateInterval("P1D");
                 $range2 = new DatePeriod($fechaDesde2, $interval, $fechaHasta2);
                 
                 foreach ( $range2 as $date ) {
-                    $date->setTime('23', '59', '59');
                     
                     $texto = '';
                     if ($historia->getFecha() <= $date && ($historia->getFechaFin() >= $date) or ($historia->getFechaFin() == null) ) {
@@ -582,38 +575,38 @@ class ClienteController extends AbstractController
         $docReferentes = $doctorRepository->findByContratos(['Fisiatra', 'Director medico', 'Sub director medico'], false);
         return $this->render('cliente/historico_2.html.twig',
             [
-                'obraSociales' => $obArray,
-                'from' => $from,
-                'to' => $to,
-                'vto' => $vto,
-                'nombre' => $nombre,
-                'obraSocial' => $obraSocial,
-                'prof' => $prof,
-                'profesionales' => $docReferentes,
-                'modalidad' => $modalidad,
-                'hab' => $hab,
-                'paginaImprimible' => true,
-                'hc' => $hc,
-                'historiaPacienteRepository' => $historiaPacienteRepository,
-                'habitacionRepository' => $habitacionRepository,
-                'doctorRepository' => $doctorRepository,
-                'clienteRepository' => $clienteRepository,
-                'range' => $range,
-                'historias' => $historias,
-                'limit' => $limit,
-                'currentPage' => $currentPage,
-                'total' => count($arrayParaLaVista),
-                'pacientes' => $arrayParaLaVista,
-                'totales' => $totales,
-                'referentes' => $referentes,
-                'obrasSocialesTotales' => $obrasSocialesTotales,
-                'totalReferentes' => $totalReferentes,
-                'internadosCount' => $internadosCount,
-                'derivadosCount' => $derivadosCount,
-                'ambulatoriosCount' => $ambulatoriosCount,
-                'sinModalidadCount' => $sinModalidadCount,
-                'egresosCount' => $egresosCount,
-                'osTotal' => $osTotal,
+                'obraSociales'                  => $obArray,
+                'from'                          => $from,
+                'to'                            => $to,
+                'vto'                           => $vto,
+                'nombre'                        => $nombre,
+                'obraSocial'                    => $obraSocial,
+                'prof'                          => $prof,
+                'profesionales'                 => $docReferentes,
+                'modalidad'                     => $modalidad,
+                'hab'                           => $hab,
+                'paginaImprimible'              => true,
+                'hc'                            => $hc,
+                'historiaPacienteRepository'    => $historiaPacienteRepository,
+                'habitacionRepository'          => $habitacionRepository,
+                'doctorRepository'              => $doctorRepository,
+                'clienteRepository'             => $clienteRepository,
+                'range'                         => $range,
+                'historias'                     => $historias,
+                'limit'                         => $limit,
+                'currentPage'                   => $currentPage,
+                'total'                         => count($arrayParaLaVista),
+                'pacientes'                     => $arrayParaLaVista,
+                'totales'                       => $totales,
+                'referentes'                    => $referentes,
+                'obrasSocialesTotales'          => $obrasSocialesTotales,
+                'totalReferentes'               => $totalReferentes,
+                'internadosCount'               => $internadosCount,
+                'derivadosCount'                => $derivadosCount,
+                'ambulatoriosCount'             => $ambulatoriosCount,
+                'sinModalidadCount'             => $sinModalidadCount,
+                'egresosCount'                  => $egresosCount,
+                'osTotal'                       => $osTotal,
             ]);
     }
 
@@ -644,17 +637,14 @@ class ClienteController extends AbstractController
             $obArray[$ob->getId()] = $ob->getNombre();
         }
 
-        $from = $request->get('from', '01/01/2000');
-        $to = $request->get('to', '31/12/3000');
+        $f          = new \DateTime('first day of this month');
+        $l          = new \DateTime('last day of this month');
+        $from       = $request->get('from' , $f->format('Y-m-d'));
+        $to         = $request->get('to', $l->format('Y-m-d'));  
+        $fechaDesde = $from ? new \DateTime($from. '0:0:0') : $from;
+        $fechaHasta = $to   ? new \DateTime($to. '23:59:59'): $to;
 
-        $fechaDesde = \DateTime::createFromFormat("d/m/Y", $from);
-        $from = date("Y-m-d", strtotime($fechaDesde->format('Y/m/d')));
-
-
-        $fechaHasta = \DateTime::createFromFormat("d/m/Y", $to);
-        $to = date("Y-m-d", strtotime($fechaHasta->format('Y/m/d')));
-
-        $clientes = $clienteRepository->findActivosDesdeHasta($fechaDesde, $fechaHasta, $nombre, $estado, $obraSocial);
+        $clientes   = $clienteRepository->findActivosDesdeHasta($fechaDesde, $fechaHasta, $nombre, $estado, $obraSocial);
 
         $historiasArray = [];
 
@@ -693,19 +683,19 @@ class ClienteController extends AbstractController
         $profesionales = $doctorRepository->findAll();
 
         return $this->render('cliente/novedades.html.twig', [
-            'clientes' => $clientes,
-            'estado' => $estado,
-            'nombreInput' => $nombreInput,
-            'habitacionesArray'=>$habitacionesArray,
-            'paginaImprimible' => true,
-            'oSociales' => $obArray,
-            'obraSocial' => $obraSocial,
-            'from' => $fechaDesde->format('d/m/Y'),
-            'to' => $fechaHasta->format('d/m/Y'),
-            'nombre' => $nombre,
-            'profesionales' => $profesionales,
-            'prof' => $prof,
-            'historiasArray' => $historiasArray,
+            'clientes'          => $clientes,
+            'estado'            => $estado,
+            'nombreInput'       => $nombreInput,
+            'habitacionesArray' => $habitacionesArray,
+            'paginaImprimible'  => true,
+            'oSociales'         => $obArray,
+            'obraSocial'        => $obraSocial,
+            'from'              => $from,
+            'to'                => $to,
+            'nombre'            => $nombre,
+            'profesionales'     => $profesionales,
+            'prof'              => $prof,
+            'historiasArray'    => $historiasArray,
         ]);
     }
 
@@ -775,22 +765,6 @@ class ClienteController extends AbstractController
             foreach ($doctoresReferentes as $doctor) {
                 $doctor->addCliente($cliente);
                 $entityManager->persist($doctor);
-            }
-
-            if (!empty($form->get('fIngreso')->getData())) {
-                $cliente->setFIngreso(\DateTime::createFromFormat('d/m/Y', $form->get('fIngreso')->getData()));
-            }
-            $cliente->setFNacimiento(null);
-            if (!empty($form->get('fNacimiento')->getData())) {
-                $cliente->setFNacimiento(\DateTime::createFromFormat('d/m/Y', $form->get('fNacimiento')->getData()));
-            }
-            $cliente->setVtoSesiones(null);
-            if (!empty($form->get('vtoSesiones')->getData())) {
-                $cliente->setVtoSesiones(\DateTime::createFromFormat('d/m/Y', $form->get('vtoSesiones')->getData()));
-            }
-            $cliente->setFEgreso(null);
-            if (!empty($form->get('fEgreso')->getData())) {
-                $cliente->setFEgreso(\DateTime::createFromFormat('d/m/Y', $form->get('fEgreso')->getData()));
             }
 
             $entityManager->persist($cliente);
@@ -871,8 +845,6 @@ class ClienteController extends AbstractController
     {
         $user = $this->security->getUser();
 
-        $docReferentesList = $doctorRepository->findDocReferente();
-
         $habitacionesDisp = $habitacionRepository->findHabitacionConCamasDisponibles($clienteRepository);
         $obrasSociales = $obraSocialRepository->findAll();
         $familiarExtraActuales = $familiarExtraRepository->findBy(['cliente_id' => $cliente->getId()]);
@@ -921,13 +893,6 @@ class ClienteController extends AbstractController
             }
         }
 
-        $formFechas = array(
-            'fIngreso' => ($cliente->getFIngreso()) ? $cliente->getFIngreso()->format('d/m/Y') : null,
-            'fNacimiento' => ($cliente->getFNacimiento()) ? $cliente->getFNacimiento()->format('d/m/Y') : null,
-            'vtoSesiones' => ($cliente->getVtoSesiones()) ? $cliente->getVtoSesiones()->format('d/m/Y') : null,
-            'fEgreso' => ($cliente->getFEgreso()) ? $cliente->getFEgreso()->format('d/m/Y') : null,
-        );
-
         $form = $this->createForm(ClienteType::class, $cliente, [
             'allow_extra_fields'=>true,
             'is_new' => false,
@@ -935,7 +900,6 @@ class ClienteController extends AbstractController
             'habitaciones' => array_flip($haArray),
             'camasDisp' => $camasDispArray,
             'bloquearHab' => $puedePasarHabPrivada,
-            'fechas' => $formFechas,
             'egreso_needed' => true,
         ]);
 
@@ -947,22 +911,6 @@ class ClienteController extends AbstractController
                 $cliente->setNCama($request->request->get('cliente')['nCama'] ?? 0);
             }
             try {
-
-                if ($form->has('fIngreso') && !empty($form->get('fIngreso')->getData())) {
-                    $cliente->setFIngreso(\DateTime::createFromFormat('d/m/Y', $form->get('fIngreso')->getData()));
-                }
-
-                if ($form->has('fNacimiento') && !empty($form->get('fNacimiento')->getData())) {
-                    $cliente->setFNacimiento(\DateTime::createFromFormat('d/m/Y', $form->get('fNacimiento')->getData()));
-                }
-
-                if ($form->has('vtoSesiones') && !empty($form->get('vtoSesiones')->getData())) {
-                    $cliente->setVtoSesiones(\DateTime::createFromFormat('d/m/Y', $form->get('vtoSesiones')->getData()));
-                }
-
-                if ($form->has('fEgreso') && !empty($form->get('fEgreso')->getData())) {
-                    $cliente->setFEgreso(\DateTime::createFromFormat('d/m/Y', $form->get('fEgreso')->getData()));
-                }
 
                 $cliente->setAmbulatorio($form->get('modalidad')->getData() == 1);
                 $entityManager = $this->getDoctrine()->getManager();
@@ -1432,17 +1380,13 @@ class ClienteController extends AbstractController
             'Neumonologo',
         ];
 
-        $notasDesde = $request->query->get('notasDesde') ?? '';
-        $notasHasta = $request->query->get('notasHasta') ?? '';
-        $notasTipo = $request->query->get('notasTipo') ?? '';
-        $section = $request->query->get('section') ?? '';
+        $evolucionesDesde   = $request->get('evolucionesDesde');
+        $evolucionesHasta   = $request->get('evolucionesHasta');  
+        $fechaDesde         = $evolucionesDesde   ? new \DateTime($evolucionesDesde. '0:0:0')   : $evolucionesDesde;
+        $fechaHasta         = $evolucionesHasta   ? new \DateTime($evolucionesHasta. '23:59:59'): $evolucionesHasta;
+        $tiposEvolucion     = $request->query->get('filtrarPorTipo') ?? [];
 
-        $evolucionesDesde = $request->query->get('evolucionesDesde') ?? '';
-        $evolucionesHasta = $request->query->get('evolucionesHasta') ?? '';
-
-        $tiposEvolucion = $request->query->get('filtrarPorTipo') ?? [];
-
-        $evoluciones = $evolucionRepository->findByFechaClienteYtipos($cliente, $evolucionesDesde, $evolucionesHasta, $tiposEvolucion);
+        $evoluciones = $evolucionRepository->findByFechaClienteYtipos($cliente, $fechaDesde, $fechaHasta, $tiposEvolucion);
 
         $docId = $request->query->get('prof', 0);
         $doc = $doctorRepository->find($docId);
@@ -1486,11 +1430,12 @@ class ClienteController extends AbstractController
             }
         }
 
-        $novedadesDesde = $request->query->get('novedadesDesde') ?? '';
-        $novedadesHasta = $request->query->get('novedadesHasta') ?? '';
+        $novedadesDesde   = $request->get('novedadesDesde');
+        $novedadesHasta   = $request->get('novedadesHasta');  
+        $fechaDesde       = $novedadesDesde   ? new \DateTime($novedadesDesde. '0:0:0')   : $novedadesDesde;
+        $fechaHasta       = $novedadesHasta   ? new \DateTime($novedadesHasta. '23:59:59'): $novedadesHasta;
 
-
-        $historiaPaciente = $historiaPacienteRepository->getHistorialDesdeHasta($cliente, $novedadesDesde, $novedadesHasta);
+        $historiaPaciente = $historiaPacienteRepository->getHistorialDesdeHasta($cliente, $fechaDesde, $fechaHasta);
 
         $obrasSociales = $obraSocialRepository->findAll();
         $obraSocialesArray = [];
@@ -1498,14 +1443,22 @@ class ClienteController extends AbstractController
             $obraSocialesArray[$obraSocial->getId()] = $obraSocial->getNombre();
         }
 
-        $turnos = [];
-        $doctores = "";
-        $notasTurnos = [];
+        $notasDesde   = $request->get('notasDesde');
+        $notasHasta   = $request->get('notasHasta');  
+        $fechaDesde   = $notasDesde   ? new \DateTime($notasDesde. '0:0:0')   : $notasDesde;
+        $fechaHasta   = $notasHasta   ? new \DateTime($notasHasta. '23:59:59'): $notasHasta;
+        $notasTipo    = $request->query->get('notasTipo') ?? '';
+        $section      = $request->query->get('section') ?? '';
+
+        $turnos         = [];
+        $doctores       = "";
+        $notasTurnos    = [];
+
         if($notasTipo) {
             $arrTipo = [$notasTipo];
             $doctores = $doctorRepository->findByContratos($arrTipo, null);
             foreach ($doctores as $doctor) {
-                $turnos[] = $bookingRepository->turnosConFiltro($doctor, $cliente->getId(), $notasDesde, $notasHasta, 1);
+                $turnos[] = $bookingRepository->turnosConFiltro($doctor, $cliente->getId(), $fechaDesde, $fechaHasta, 1);
                 foreach ($turnos as $turno) {
                     $notas = $notasTurnoRepository->findBy(['turno' => $turno] );
                     if ( !empty($notas) ) {
@@ -1520,7 +1473,7 @@ class ClienteController extends AbstractController
             }
             dd($turnos);
         } else {
-            $turnos = $bookingRepository->turnosConFiltro('', $cliente->getId(), $notasDesde, $notasHasta, 1);
+            $turnos = $bookingRepository->turnosConFiltro('', $cliente->getId(), $fechaDesde, $fechaHasta, 1);
             foreach ($turnos as $turno) {
                 $notas = $notasTurnoRepository->findBy(['turno' => $turno] );
                 if ( !empty($notas) ) {
@@ -1543,31 +1496,31 @@ class ClienteController extends AbstractController
         }
 
         return $this->render('cliente/historia.html.twig', [
-                'cliente' => $cliente,
-                'historiaPaciente' => $historiaPaciente,
-                'obraSociales' => $obraSocialesArray,
-                'paginaImprimible' => false,//local
-                'notasTurnos' => $notasTurnos,
-                'notasHistoria' => $notasHistoria,
-                'titulo_solo' => true,
-                'evoluciones' => $evArray,
-                'ingreso' => $cliente->getHistoriaIngreso(),
-                'historiaEgreso' => $historiaEgreso,
-                'tipoSeleccionado' => '',
-                'notasDesde' => $notasDesde,
-                'notasHasta' => $notasHasta,
-                'notasTipo' => $notasTipo,
-                'section' => $section,
-                'contratos' => $tipos,
-                'tipoEvolucion' => $tiposEvolucion,
-                'evolucionesDesde' => $evolucionesDesde,
-                'evolucionesHasta' => $evolucionesHasta,
-                'puedeEditarEvolucion' => $puedenEditarEvoluciones,
-                'habitacionesArray' => $habitacionesArray,
-                'novedadesDesde' => $novedadesDesde,
-                'novedadesHasta' => $novedadesHasta,
-                'doc' => $doc,
-                'doctorRepository' => $doctorRepository,
+                'cliente'               => $cliente,
+                'historiaPaciente'      => $historiaPaciente,
+                'obraSociales'          => $obraSocialesArray,
+                'paginaImprimible'      => false,//local
+                'notasTurnos'           => $notasTurnos,
+                'notasHistoria'         => $notasHistoria,
+                'titulo_solo'           => true,
+                'evoluciones'           => $evArray,
+                'ingreso'               => $cliente->getHistoriaIngreso(),
+                'historiaEgreso'        => $historiaEgreso,
+                'tipoSeleccionado'      => '',
+                'notasDesde'            => $notasDesde,
+                'notasHasta'            => $notasHasta,
+                'notasTipo'             => $notasTipo,
+                'section'               => $section,
+                'contratos'             => $tipos,
+                'tipoEvolucion'         => $tiposEvolucion,
+                'evolucionesDesde'      => $evolucionesDesde,
+                'evolucionesHasta'      => $evolucionesHasta,
+                'puedeEditarEvolucion'  => $puedenEditarEvoluciones,
+                'habitacionesArray'     => $habitacionesArray,
+                'novedadesDesde'        => $novedadesDesde,
+                'novedadesHasta'        => $novedadesHasta,
+                'doc'                   => $doc,
+                'doctorRepository'      => $doctorRepository,
         ]);
     }
 

--- a/src/Controller/ClienteController.php
+++ b/src/Controller/ClienteController.php
@@ -1561,15 +1561,19 @@ class ClienteController extends AbstractController
                 $entityManager->persist($doctor);
             }
             if ($form->has('fEgreso') && !empty($form->get('fEgreso')->getData())) {
-                $cliente->setFEgreso(\DateTime::createFromFormat('d/m/Y', $form->get('fEgreso')->getData()));
+                $cliente->setFEgreso($form->get('fEgreso')->getData());
             }
+            
+            $fEgresoCliente = $cliente->getFEgreso();
 
-            $fechaDeEgresoString = $cliente->getFEgreso()->setTime(00, 00, 00)->format('Y-m-d H:i:s');
+            if ( $fEgresoCliente instanceof \DateTime ) {
+                $fechaDeEgresoString = $fEgresoCliente->setTime(00, 00, 00)->format('Y-m-d H:i:s');
 
-            $turnos = $bookingRepository->turnosConFiltro('', $cliente, $fechaDeEgresoString);
-
-            foreach ($turnos as $turno) {
-                $entityManager->remove($turno);
+                $turnos = $bookingRepository->turnosConFiltro('', $cliente, $fechaDeEgresoString);
+    
+                foreach ($turnos as $turno) {
+                    $entityManager->remove($turno);
+                }
             }
 
             $entityManager->persist($cliente);

--- a/src/Controller/DashboardController.php
+++ b/src/Controller/DashboardController.php
@@ -87,24 +87,16 @@ class DashboardController extends AbstractController
      */
     public function getPacientesFromTo(Request $request, ObraSocialRepository $obraSocialRepository, HistoriaHabitacionesRepository $historiaHabitacionesRepository) {
 
-        $from = $request->get('from', '2000/12/01');
-        $to = $request->get('to', '2121/12/31');
+        $from       = $request->get('from');
+        $to         = $request->get('to');    
+        $fechaDesde = $from ? new \DateTime($from. '0:0:0') : $from ;
+        $fechaHasta = $to   ? new \DateTime($to. '23:59:59'): $to;
 
-        $fechaDesde = \DateTime::createFromFormat("d/m/Y", $from);
-        $from = date("Y-m-d", strtotime($fechaDesde->format('Y/m/d')));
-
-
-        $fechaHasta = \DateTime::createFromFormat("d/m/Y", $to);
-        $to = date("Y-m-d", strtotime($fechaHasta->format('Y/m/d')));
-
-        $historias = $historiaHabitacionesRepository->findByDate($from,  $to);
+        $historias = $historiaHabitacionesRepository->findByDate($fechaDesde,  $fechaHasta);
 
         $obrasSociales = $this->getOSarray($obraSocialRepository);
 
         $arrHistorias = [];
-
-        $dateFrom = new \DateTime($from);
-        $dateTo = new \DateTime($to);
 
         $arrHistorias['clientes'] = [];
 

--- a/src/Controller/EvolucionController.php
+++ b/src/Controller/EvolucionController.php
@@ -29,17 +29,17 @@ class EvolucionController extends AbstractController
      */
     public function index(Request $request, EvolucionRepository $evolucionRepository, ClienteRepository $clienteRepository): Response
     {
-        $user = $this->getUser();
-        $tipoSeleccionado = $request->query->get('tipoSeleccionado', 0);
-        $limit = $request->query->get('limit', 100);
-        $currentPage = $request->query->get('currentPage', 1);
-        $f = new \DateTime('first day of this month');
-        $l = new \DateTime('last day of this month');
-        $from = $request->get('from', $f->format('d/m/Y'));
-        $to = $request->get('to', $l->format('d/m/Y'));
-        
-        $fechaDesde = \DateTime::createFromFormat("d/m/Y", $from);
-        $fechaHasta = \DateTime::createFromFormat("d/m/Y", $to);
+        $user               = $this->getUser();
+        $tipoSeleccionado   = $request->query->get('tipoSeleccionado', 0);
+        $limit              = $request->query->get('limit', 100);
+        $currentPage        = $request->query->get('currentPage', 1);
+
+        $f          = new \DateTime('first day of this month');
+        $l          = new \DateTime('last day of this month');
+        $from       = $request->get('from' , $f->format('Y-m-d'));
+        $to         = $request->get('to', $l->format('Y-m-d'));  
+        $fechaDesde = $from ? new \DateTime($from. '0:0:0') : $from;
+        $fechaHasta = $to   ? new \DateTime($to. '23:59:59'): $to;
 
         $modalidades = [];
         if($user instanceOf Doctor) {
@@ -64,16 +64,16 @@ class EvolucionController extends AbstractController
         
 
         return $this->render('evolucion/index.html.twig', [
-            'nombreCliente' => $cliente->getNombre() . ' ' . $cliente->getApellido(),
-            'evolucions' => $evoluciones['paginator'],
-            'all_items' => $evoluciones['query'],
-            'clienteId' => $cliente->getId(),
-            'tipoSeleccionado' => $tipoSeleccionado,
-            'maxPages'=> $maxPages,
-            'thisPage' => $currentPage,
-            'clientId' => $clientId,
-            'fechaDesde' => $from ?? 'elija una fecha',
-            'fechaHasta' => $to ?? 'elija una fecha',
+            'nombreCliente'     => $cliente->getNombre() . ' ' . $cliente->getApellido(),
+            'evolucions'        => $evoluciones['paginator'],
+            'all_items'         => $evoluciones['query'],
+            'clienteId'         => $cliente->getId(),
+            'tipoSeleccionado'  => $tipoSeleccionado,
+            'maxPages'          => $maxPages,
+            'thisPage'          => $currentPage,
+            'clientId'          => $clientId,
+            'fechaDesde'        => $from,
+            'fechaHasta'        => $to,
         ]);
     }
 

--- a/src/Form/BookingType.php
+++ b/src/Form/BookingType.php
@@ -26,8 +26,8 @@ class BookingType extends AbstractType
         $this->isNew = $options['isNew'];
 
         $builder
-            ->add('beginAt', DateTimeType::class, ['label' => 'Hora de Inicio', 'required' => true, 'widget' => 'single_text', 'html5' => true, 'attr' => ['class' => 'js-datepicker'],])
-            ->add('endAt', DateTimeType::class, ['label' => 'Hora de Inicio', 'required' => true, 'widget' => 'single_text', 'html5' => true, 'attr' => ['class' => 'js-datepicker'],])
+            ->add('beginAt', DateTimeType::class, ['label' => 'Hora de Inicio', 'required' => true, 'widget' => 'single_text', 'html5' => true])
+            ->add('endAt', DateTimeType::class, ['label' => 'Hora de Inicio', 'required' => true, 'widget' => 'single_text', 'html5' => true])
             ->add('title', TextType::class, ['label' => 'Titulo'])
             ->add('doctor', EntityType::class, [
                 'class' => Doctor::class,
@@ -69,8 +69,8 @@ class BookingType extends AbstractType
                     'multiple'=>true,
                     'expanded'=>true,
                 ])
-                    ->add('desde', DateType::class, ['label' => 'Desde', 'required' => false, 'widget' => 'single_text', 'html5' => true, 'attr' => ['class' => 'js-datepicker'],])
-                    ->add('hasta', DateType::class, ['label' => 'Hasta', 'required' => false, 'widget' => 'single_text', 'html5' => true, 'attr' => ['class' => 'js-datepicker'],]);
+                    ->add('desde', DateType::class, ['label' => 'Desde', 'required' => false, 'widget' => 'single_text', 'html5' => true])
+                    ->add('hasta', DateType::class, ['label' => 'Hasta', 'required' => false, 'widget' => 'single_text', 'html5' => true]);
             };
             $builder
             ->add('save', SubmitType::class, ['label' => 'Guardar', 'attr' => ['class' => 'btn-success']])

--- a/src/Form/ClienteType.php
+++ b/src/Form/ClienteType.php
@@ -2,24 +2,25 @@
 
 namespace App\Form;
 
-use App\Entity\Cliente;
+use Svg\Tag\Text;
 use App\Entity\Doctor;
+use App\Entity\Cliente;
 use App\Entity\ObraSocial;
 use Doctrine\ORM\EntityRepository;
-use Svg\Tag\Text;
-use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Form\Extension\Core\Type\DateType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
-use Symfony\Component\Form\Extension\Core\Type\TextType;
-use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Form\FormEvent;
-use Symfony\Component\Form\FormEvents;
-use Symfony\Component\Form\FormInterface;
-use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ClienteType extends AbstractType
 {
@@ -27,7 +28,6 @@ class ClienteType extends AbstractType
     {
         $obrasSociales = $options['obrasSociales'] ?? '';
         $habitaciones = $options['habitaciones'] ?? '';
-        $fechas = $options['fechas'] ?? '';
 
         ksort($obrasSociales);
         if (!$options['egreso']) {
@@ -37,11 +37,9 @@ class ClienteType extends AbstractType
                 ->add('dni', TextType::class, ['label' => 'Número de Documento', 'required' => false,])
                 ->add('email', EmailType::class, ['required' => false,])
                 ->add('telefono', TextType::class, ['label' => 'Teléfono', 'required' => false,])
-                ->add('fNacimiento', TextType::class, [
-                    'label' => 'Fecha de Nacimiento',
-                    'required' => false,
-                    'attr' => ['class' => 'js-datepicker', 'autocomplete'=>'off', 'value' => $fechas['fNacimiento']],
-                    'mapped' => false
+                ->add('fNacimiento', DateType::class, [
+                    'widget' => 'single_text',
+                    'required' => false
                     ])
                 ->add('hClinica', TextType::class, ['label' => 'Número de Historia Clínica', 'required' => false,])
                 ->add('obraSocial', EntityType::class, [
@@ -72,12 +70,10 @@ class ClienteType extends AbstractType
                 ->add('sistemaDeEmergenciaNombre', TextType::class, ['required' => false, 'label' => 'Sistema de emergencias'])
                 ->add('sistemaDeEmergenciaTel', TextType::class, ['required' => false, 'label' => 'Teléfono'])
                 ->add('sistemaDeEmergenciaAfiliado', TextType::class, ['required' => false, 'label' => 'N Afiliado'])
-                ->add('fIngreso', TextType::class, [
-                    'label' => 'Fecha de Ingreso',
-                    'required' => true,
-                    'mapped' => false,
-                    'attr' => ['class' => 'js-datepicker', 'autocomplete'=>'off', 'value' => $fechas['fIngreso']]],
-                )
+                ->add('fIngreso', DateType::class, [
+                    'widget' => 'single_text',
+                    'required' => true
+                ])
                 ->add('modalidad', ChoiceType::class, [
                     'label' => 'Modalidad',
                     'placeholder' => 'Seleccione una modalidad',
@@ -160,12 +156,10 @@ class ClienteType extends AbstractType
                 ->add('dieta', TextType::class, ['label' => 'Dieta', 'required' => false])
                 ->add('sesionesDisp', NumberType::class, ['label' => 'Sesiones Disponibles', 'required' => false, 'html5' => true])
                 ->add('formNum', NumberType::class, ['label' => 'Número de Formulario', 'required' => false, 'html5' => true])
-                ->add('vtoSesiones', TextType::class, [
-                    'label' => 'Vto Autorizaciones',
-                    'mapped' => false,
-                    'required' => false,
-                    'attr' => ['class' => 'js-datepicker', 'autocomplete'=>'off', 'value' => $fechas['vtoSesiones']]],
-                )
+                ->add('vtoSesiones', DateType::class, [
+                    'widget' => 'single_text',
+                    'required' => false
+                ])
                 ->add('mediaSesion', ChoiceType::class, ['label' => 'Media sesion?', 'required' => false, 'choices' => [
                     'Si' => true,
                     'No' => false,
@@ -199,11 +193,10 @@ class ClienteType extends AbstractType
             }
             if($options['egreso'] || $options['is_new'] || $options['egreso_needed']) {
                 $builder
-                    ->add('fEgreso', TextType::class, [
-                        'mapped' => false,
+                    ->add('fEgreso', DateType::class, [
+                        'widget' => 'single_text',
                         'required' => false,
-                        'attr' => ['class' => 'js-datepicker', 'autocomplete'=>'off', 'value' => $fechas['fEgreso']]],
-                    )
+                    ])
                     ->add('motivoEgr', ChoiceType::class, [
                         'label' => 'Motivo de Egreso',
                         'choices'  => [

--- a/src/Form/DoctorType.php
+++ b/src/Form/DoctorType.php
@@ -406,7 +406,7 @@ class DoctorType extends AbstractType
         //campos a mostrar para staff existente
         elseif($options['egreso']) {
             $builder
-                ->add('fechaBaja', DateType::class, [ 'widget' => 'single_text', 'required' => false, 'attr' => ['class' => 'js-datepicker']])
+                ->add('fechaBaja', DateType::class, [ 'widget' => 'single_text', 'required' => false])
                 ->add('motivoBaja', ChoiceType::class,
                     [
                         'label' => 'Motivo de la Baja',

--- a/src/Form/EvolucionType.php
+++ b/src/Form/EvolucionType.php
@@ -37,7 +37,7 @@ class EvolucionType extends AbstractType
             ->add('description', TextareaType::class, [
                 'attr' => ['style' => 'min-height:12rem', 'class' => 'ckeditor']
             ])
-            ->add('fecha', DateType::class, ['label' => 'Fecha', 'required' => true, 'widget' => 'single_text', 'html5' => true, 'attr' => ['class' => 'js-datepicker', "max" => $today->format('Y-m-d')]])
+            ->add('fecha', DateType::class, ['label' => 'Fecha', 'required' => true, 'widget' => 'single_text', 'html5' => true, 'attr' => ["max" => $today->format('Y-m-d')]])
             ->add('adjunto', FileType::class, [
                 'data_class'=>null,
                 'label' => 'Adjunto (PDF)',

--- a/src/Repository/BookingRepository.php
+++ b/src/Repository/BookingRepository.php
@@ -88,20 +88,12 @@ class BookingRepository extends ServiceEntityRepository
         }
 
         if(!empty($desde)) {
-            $from = (new \DateTime($desde));
-            $from->setTime(00, 00, 00);
-            $desde = $from->format("Y-m-d H:i:s");
-
             $query = $query
                 ->andWhere('b.beginAt >= :desde')
                 ->setParameter('desde', $desde);
         }
 
         if(!empty($hasta)) {
-            $to = (new \DateTime($hasta));
-            $to->setTime(23, 59, 59);
-            $hasta = $to->format("Y-m-d H:i:s");
-
             $query = $query
                 ->andWhere('b.endAt <= :hasta')
                 ->setParameter('hasta', $hasta);

--- a/src/Repository/ClienteRepository.php
+++ b/src/Repository/ClienteRepository.php
@@ -61,10 +61,14 @@ class ClienteRepository extends ServiceEntityRepository
     // modalidad 1 es ambulatorio
     public function findActivosDesdeHasta($from, $to, $nombre, $estado, $obraSocial)
     {
-        $query = $this->createQueryBuilder('c')
-            ->andWhere('c.fIngreso >= :from')->setParameter('from', $from)
-            ->andWhere('c.fEgreso <= :to')->setParameter('to', $to)
-            ->orWhere('c.fEgreso IS NULL');
+        $query = $this->createQueryBuilder('c');
+        if (!empty($from)){
+            $query->andWhere('c.fIngreso >= :from')->setParameter('from', $from);
+        }
+        if (!empty($to)){
+            $query->andWhere('c.fEgreso <= :to')->setParameter('to', $to);
+        }          
+        $query->orWhere('c.fEgreso IS NULL');
 
         if ( $nombre != '' ) {
             $arrayNombres = explode(' ', $nombre);

--- a/src/Repository/EvolucionRepository.php
+++ b/src/Repository/EvolucionRepository.php
@@ -30,12 +30,12 @@ class EvolucionRepository extends ServiceEntityRepository
                 ->setParameter('tipo', $tipo);
         }
 
-        if ( $from ) {
+        if (!empty($from)) {
             $query->andWhere('e.fecha >= :from')
                 ->setParameter('from', $from);
         }
 
-        if ( $to ) {
+        if (!empty($to)) {
             $query->andWhere('e.fecha <= :to')
                 ->setParameter('to', $to);
         }
@@ -83,11 +83,9 @@ class EvolucionRepository extends ServiceEntityRepository
     {
         $query = $this->createQueryBuilder('e')->where('e.user = :doctor')->setParameter('doctor', $doctor);
             if (!empty($fechaDesde)) {
-                $fechaDesde->setTime(0,0,0);
                 $query->andWhere('e.fecha >= :fechaDesde')->setParameter('fechaDesde', $fechaDesde);
             }
             if (!empty($fechaHasta)) {
-                $fechaHasta->setTime(23,59,59);
                 $query->andWhere('e.fecha <= :fechaHasta')->setParameter('fechaHasta', $fechaHasta);
             }
             if (!empty($cliente)) {
@@ -124,16 +122,10 @@ class EvolucionRepository extends ServiceEntityRepository
 
 
         if (!empty($fechaDesde)) {
-
-            $fechaDesde = \DateTime::createFromFormat("d/m/Y", $fechaDesde);
-            $newDate = date("Y/m/d", strtotime($fechaDesde->format('Y/m/d')));
-            $query->andWhere('e.fecha >= :fechaDesde')->setParameter('fechaDesde', $newDate);
+            $query->andWhere('e.fecha >= :fechaDesde')->setParameter('fechaDesde', $fechaDesde);
         }
         if (!empty($fechaHasta)) {
-            $fechaHasta = \DateTime::createFromFormat("d/m/Y", $fechaHasta);
-            $fechaHasta->setTime(23,59,59);
-            $newDate = date("Y/m/d", strtotime($fechaHasta->format('Y/m/d')));
-            $query->andWhere('e.fecha <= :fechaHasta')->setParameter('fechaHasta', $newDate);
+            $query->andWhere('e.fecha <= :fechaHasta')->setParameter('fechaHasta', $fechaHasta);
         }
         if ( !empty($tipos) ) {
             $query->andWhere('e.tipo IN (:tipos)')->setParameter('tipos', $tipos);

--- a/src/Repository/HistoriaPacienteRepository.php
+++ b/src/Repository/HistoriaPacienteRepository.php
@@ -52,15 +52,10 @@ class HistoriaPacienteRepository extends ServiceEntityRepository
             ->andWhere('h.cliente = :cliente')
             ->setParameter('cliente', $cliente);
         if (!empty($from)) {
-            $fechaDesde = \DateTime::createFromFormat("d/m/Y", $from);
-            $newDate = date("Y/m/d", strtotime($fechaDesde->format('Y/m/d')));
-            $query->andWhere('h.fecha >= :fechaDesde')->setParameter('fechaDesde', $newDate);
+            $query->andWhere('h.fecha >= :fechaDesde')->setParameter('fechaDesde', $from);
         }
         if (!empty($to)) {
-            $fechaHasta = \DateTime::createFromFormat("d/m/Y", $to);
-            $fechaHasta->setTime(23,59,59);
-            $newDate = date("Y/m/d", strtotime($fechaHasta->format('Y/m/d')));
-            $query->andWhere('h.fecha <= :fechaHasta')->setParameter('fechaHasta', $newDate);
+            $query->andWhere('h.fecha <= :fechaHasta')->setParameter('fechaHasta', $to);
         }
         $query->orderBy('h.fecha, h.id', 'ASC');
 
@@ -156,15 +151,15 @@ class HistoriaPacienteRepository extends ServiceEntityRepository
 
     public function findLastChange($clienteId, $to)
     {
-        if ( empty($to) ) {
-            $to = '9999-01-01';
-        }
-        $query = $this->createQueryBuilder('h')
-            ->andWhere('h.fecha <= :to')->setParameter('to', $to)
-            ->andWhere('h.cliente = :cliente')->setParameter('cliente', $clienteId)
+        $query = $this->createQueryBuilder('h');
+        
+        if (!empty($to) ) {
+            $query->andWhere('h.fecha <= :to')->setParameter('to', $to);
+        }   
+        $query->andWhere('h.cliente = :cliente')->setParameter('cliente', $clienteId)
             ->orderBy('h.fecha', 'DESC');
 
-            return $query->getQuery()->getResult();
+        return $query->getQuery()->getResult();
     }
 
     public function getHistoricoDesdeHasta($desde, $hasta, $nombre = null, $modalidad = 0, $obraSocial = null, $prof = null, $hc = null) {

--- a/templates/booking/index.html.twig
+++ b/templates/booking/index.html.twig
@@ -16,13 +16,13 @@
                             Desde:
                         </div>
                         <div class="col-5">
-                            <input name='from' type="date" class="js-datepicker form-control" value="{{ desde }}">
+                            <input name='from' type="date" class="form-control" value="{{ desde }}">
                         </div>
                         <div class="col-1" style="display: flex;align-items: center;justify-content: flex-end;">
                             Hasta:
                         </div>
                         <div class="col-5">
-                            <input name='to' type="date" class="js-datepicker form-control" value="{{ hasta }}">
+                            <input name='to' type="date" class="form-control" value="{{ hasta }}">
                         </div>
                     </div>
                 </div>
@@ -106,8 +106,8 @@
                 <td class="profesional" style="text-transform: capitalize">{{ booking.doctor.nombre }} {{ booking.doctor.apellido }}</td>
                 <td class="paciente" style="text-transform: capitalize">{{ booking.cliente.nombre }} {{ booking.cliente.apellido }}</td>
                 <td class="obraSocial">{{ obrasSociales[booking.cliente.obraSocial] }}{% if booking.cliente.MediaSesion %} (Media Sesion) {% endif %}</td>
-                <td class="comenzo">{{ booking.beginAt | date('Y-m-d H:i:s') }}</td>
-                <td class="finalizo">{{ booking.endAt | date('Y-m-d H:i:s') }}</td>
+                <td class="comenzo">{{ booking.beginAt | date('d/m/Y H:i:s') }}</td>
+                <td class="finalizo">{{ booking.endAt | date('d/m/Y H:i:s') }}</td>
                 <td class="titulo">{{ booking.completado ? 'si' : 'no' }}</td>
                 <td>
                     {% if not booking.completado %}

--- a/templates/booking/show.html.twig
+++ b/templates/booking/show.html.twig
@@ -8,11 +8,11 @@
         <tbody>
             <tr>
                 <th>Comienza</th>
-                <td>{{ booking.beginAt ? booking.beginAt|date('Y-m-d H:i:s') : '' }}</td>
+                <td>{{ booking.beginAt ? booking.beginAt|date('d/m/Y H:i:s') : '' }}</td>
             </tr>
             <tr>
                 <th>Finaliza</th>
-                <td>{{ booking.endAt ? booking.endAt|date('Y-m-d H:i:s') : '' }}</td>
+                <td>{{ booking.endAt ? booking.endAt|date('d/m/Y H:i:s') : '' }}</td>
             </tr>
             <tr>
                 <th>Titulo</th>
@@ -53,7 +53,7 @@
             </tr>
             <tr>
                 <th>Hasta</th>
-                <td>{{ booking.hasta ? booking.hasta|date('Y-m-d') : '' }}</td>
+                <td>{{ booking.hasta ? booking.hasta|date('d/m/Y') : '' }}</td>
             </tr>
         </tbody>
     </table>

--- a/templates/cliente/_form.html.twig
+++ b/templates/cliente/_form.html.twig
@@ -42,7 +42,7 @@
     <div class="col-sm">
         <div class="form-row">
             <div class="col-sm">
-                {{ form_label(form.fNacimiento) }}
+                {{ form_label(form.fNacimiento, 'Fecha de Nacimiento') }}
                 {{ form_widget(form.fNacimiento) }}
             </div>
             <div class="col-sm">
@@ -138,7 +138,7 @@
 <br>
 <div class="form-row">
     <div class="col-sm">
-        {{ form_label(form.fIngreso) }}
+        {{ form_label(form.fIngreso, 'Fecha de Ingreso') }}
         {{ form_widget(form.fIngreso) }}
     </div>
     <div class="col-sm">
@@ -167,7 +167,7 @@
 <br>
 <div class="form-row">
     <div class="col-sm">
-        {{ form_label(form.vtoSesiones) }}
+        {{ form_label(form.vtoSesiones, 'Vto. Autorizaciones') }}
         {{ form_widget(form.vtoSesiones) }}
     </div>
     <div class="col-sm">

--- a/templates/cliente/darPermiso.html.twig
+++ b/templates/cliente/darPermiso.html.twig
@@ -27,7 +27,7 @@
                             <span>Horarios</span>
                             {% for turno in turnos %}
                                 <br>
-                                <span> {{ turno.beginAt |date('m/d/Y - h:m') }}hs</span>
+                                <span> {{ turno.beginAt |date('d/m/Y - h:m') }}hs</span>
                             {% endfor %}
                         </div>
                     </div>

--- a/templates/cliente/derivar.html.twig
+++ b/templates/cliente/derivar.html.twig
@@ -40,7 +40,7 @@
                             <span>Horarios</span>
                             {% for turno in turnos %}
                                 <br>
-                                <span> {{ turno.beginAt |date('m/d/Y - h:m') }}hs</span>
+                                <span> {{ turno.beginAt |date('d/m/Y - h:m') }}hs</span>
                             {% endfor %}
                         </div>
                     </div>

--- a/templates/cliente/epicrisis.html.twig
+++ b/templates/cliente/epicrisis.html.twig
@@ -35,11 +35,11 @@
         </tr>
         <tr>
             <th>Fecha de Ingreso</th>
-            <td>{{ cliente.fIngreso ? cliente.fIngreso|date('Y-m-d') : '' }}</td>
+            <td>{{ cliente.fIngreso ? cliente.fIngreso|date('d/m/Y') : '' }}</td>
         </tr>
         <tr>
             <th>Fecha de Egreso</th>
-            <td>{{ cliente.fEgreso ? cliente.fEgreso|date('Y-m-d') : '' }}</td>
+            <td>{{ cliente.fEgreso ? cliente.fEgreso|date('d/m/Y') : '' }}</td>
         </tr>
         <tr>
             <th>Motivo de Ingreso</th>

--- a/templates/cliente/historia.html.twig
+++ b/templates/cliente/historia.html.twig
@@ -202,13 +202,13 @@
                                     <label class="control-label">desde:</label>
                                 </div>
                                 <div class="col-xl-2 col-md-6 col-lg-6 col-sm-12 text-left">
-                                    <input class="form-control js-datepicker" autocomplete="off" type="text" name="notasDesde" required value="{{ notasDesde }}">
+                                    <input class="form-control" type="date" name="notasDesde" required value="{{ notasDesde }}">
                                 </div>
                                 <div class="col-xl-1 col-md-6 col-lg-6 col-sm-12 text-right" style="line-height: 40px;height: 35px;">
                                     <label class="control-label">hasta:</label>
                                 </div>
                                 <div class="col-xl-2 col-md-6 col-lg-6 col-sm-12 text-left">
-                                    <input class="form-control js-datepicker" autocomplete="off" type="text" name="notasHasta" required value="{{ notasHasta }}">
+                                    <input class="form-control" type="date" name="notasHasta" required value="{{ notasHasta }}">
                                 </div>
                                 {#<div class="col-xl-4 col-md-6 col-lg-6 col-sm-12">
                                         <select class="form-control" id="filtrarPorTipo" name="notasTipo">
@@ -283,13 +283,13 @@
                                     <label class="control-label">desde:</label>
                                 </div>
                                 <div class="col-xl-2 col-md-6 col-lg-6 col-sm-12 text-left">
-                                    <input class="form-control js-datepicker" autocomplete="off" type="text" name="evolucionesDesde" value="{{ evolucionesDesde }}">
+                                    <input class="form-control" type="date" name="evolucionesDesde" value="{{ evolucionesDesde }}">
                                 </div>
                                 <div class="col-xl-1 col-md-6 col-lg-6 col-sm-12 text-right" style="line-height: 40px;height: 35px;">
                                     <label class="control-label">hasta:</label>
                                 </div>
                                 <div class="col-xl-2 col-md-6 col-lg-6 col-sm-12 text-left">
-                                    <input class="form-control js-datepicker" autocomplete="off" type="text" name="evolucionesHasta" value="{{ evolucionesHasta }}">
+                                    <input class="form-control" type="date" name="evolucionesHasta" value="{{ evolucionesHasta }}">
                                 </div>
                                 <div class="col-xl-4 col-md-6 col-lg-6 col-sm-12">
                                     <select class="form-control" id="filtrarPorTipo" name="filtrarPorTipo[]" multiple data-placeholder="Especialidad">
@@ -372,13 +372,13 @@
                                     <label class="control-label">desde:</label>
                                 </div>
                                 <div class="col-xl-2 col-md-6 col-lg-6 col-sm-12 text-left">
-                                    <input class="form-control js-datepicker" autocomplete="off" type="text" name="novedadesDesde" value="{{ novedadesDesde }}">
+                                    <input class="form-control" type="date" name="novedadesDesde" value="{{ novedadesDesde }}">
                                 </div>
                                 <div class="col-xl-1 col-md-6 col-lg-6 col-sm-12 text-right" style="line-height: 40px;height: 35px;">
                                     <label class="control-label">hasta:</label>
                                 </div>
                                 <div class="col-xl-2 col-md-6 col-lg-6 col-sm-12 text-left">
-                                    <input class="form-control js-datepicker" autocomplete="off" type="text" name="novedadesHasta" value="{{ novedadesHasta }}">
+                                    <input class="form-control" type="date" name="novedadesHasta" value="{{ novedadesHasta }}">
                                 </div>
                                 <div class="col-xl-1 col-md-6 col-lg-3 col-sm-6">
                                     <button type="submit" class="btn btn-default" style="width: 100%;">filtrar</button>
@@ -885,11 +885,6 @@
                 evt.cancel();
             } );
         });
-
-        $('.js-datepicker').datepicker({
-            format: 'dd/mm/yyyy'
-        });
-
 
 
     </script>

--- a/templates/cliente/historico.html.twig
+++ b/templates/cliente/historico.html.twig
@@ -11,11 +11,11 @@
         <div class="row">
             <div class="col">
                 <label for="from">Desde</label>
-                <input class="form-control js-datepicker" type="text" id="from" autocomplete="off" name="from" value="{{ from }}">
+                <input class="form-control" type="date" id="from" name="from" value="{{ from }}">
             </div>
             <div class="col">
                 <label for="to">Hasta</label>
-                <input class="form-control js-datepicker" type="text" id="to" autocomplete="off" name="to" value="{{ to }}">
+                <input class="form-control" type="date" id="to" name="to" value="{{ to }}">
             </div>
             <div class="col">
                 <label for="modalidad">Estado</label>
@@ -51,7 +51,7 @@
             </div>
             <div class="col-2">
                 <label for="vto">Vto. Autorizaciones</label>
-                <input class="form-control js-datepicker" type="text" id="vto" autocomplete="off" name="vto" value="{{ vto }}">
+                <input class="form-control" type="date" id="vto" name="vto" value="{{ vto }}">
             </div>
             <div class="col-2">
                 <label for="vto">Resultados por Página</label>
@@ -558,9 +558,6 @@
 {% block javascripts %}
     {{ parent() }}
     <script>
-        $('.js-datepicker').datepicker({
-            format: 'dd/mm/yyyy'
-        });
 
         $('.abrir').click(function (e) {
             e.preventDefault();

--- a/templates/cliente/historico_2.html.twig
+++ b/templates/cliente/historico_2.html.twig
@@ -11,11 +11,11 @@
         <div class="row">
             <div class="col">
                 <label for="from">Desde</label>
-                <input class="form-control js-datepicker" type="text" id="from" autocomplete="off" name="from" value="{{ from }}">
+                <input class="form-control" type="date" id="from" name="from" value="{{ from }}">
             </div>
             <div class="col">
                 <label for="to">Hasta</label>
-                <input class="form-control js-datepicker" type="text" id="to" autocomplete="off" name="to" value="{{ to }}">
+                <input class="form-control" type="date" id="to" name="to" value="{{ to }}">
             </div>
             <div class="col">
                 <label for="modalidad">Estado</label>
@@ -181,9 +181,6 @@
 {% block javascripts %}
     {{ parent() }}
     <script>
-        $('.js-datepicker').datepicker({
-            format: 'dd/mm/yyyy'
-        });
         
         $('form').submit(function(e) {
             $(".deshabilitar").attr('disabled', true);

--- a/templates/cliente/index.html.twig
+++ b/templates/cliente/index.html.twig
@@ -149,7 +149,7 @@
                         <td class="hClinica">{{ cliente.hClinica }}</td>
                         <td class="nombre">{{ cliente.nombre }}</td>
                         <td class="apellido">{{ cliente.apellido }}</td>
-                        <td class="fNacimiento">{{ cliente.fNacimiento ? cliente.fNacimiento|date('Y-m-d') : '' }}</td>
+                        <td class="fNacimiento">{{ cliente.fNacimiento ? cliente.fNacimiento|date('d/m/Y') : '' }}</td>
                         <td class="edad">{{ cliente.edad }}</td>
                         <td class="dni">{{ cliente.dni }}</td>
                         <td class="ultimaEvolucion" style="text-align: center">
@@ -167,7 +167,7 @@
                         </td>
                         <td class="lowercase email">{{ cliente.email }}</td>
                         <td class="telefono">{{ cliente.telefono }}</td>
-                        <td class="fIngreso">{{ cliente.fIngreso ? cliente.fIngreso|date('Y-m-d') : '' }}</td>
+                        <td class="fIngreso">{{ cliente.fIngreso ? cliente.fIngreso|date('d/m/Y') : '' }}</td>
                         <td class="motivoIng">
                             {% if(cliente.motivoIng == 1) %}
                                 Neurologicas
@@ -193,7 +193,7 @@
                                 ART
                             {% endif %}
                         </td>
-                        <td class="fEgreso">{{ cliente.fEgreso ? cliente.fEgreso|date('Y-m-d') : '' }}</td>
+                        <td class="fEgreso">{{ cliente.fEgreso ? cliente.fEgreso|date('d/m/Y') : '' }}</td>
                         <td class="motivoEgr">{{ cliente.motivoEgr }}</td>
                         <td class="obraSocial">
                             {{ cliente.obraSocial.nombre ?? 'no tiene' }}
@@ -247,19 +247,19 @@
                         <td class="disponibleParaTerapia">{{ cliente.disponibleParaTerapia }} </td>
                         <td class="derivado">{{ cliente.derivado }} </td>
                         <td class="derivadoEn">{{ cliente.derivadoEn }} </td>
-                        <td class="fechaDerivacion">{{ cliente.fechaDerivacion ? cliente.fechaDerivacion|date('Y-m-d') : ''  }} </td>
+                        <td class="fechaDerivacion">{{ cliente.fechaDerivacion ? cliente.fechaDerivacion|date('d/m/Y') : ''  }} </td>
                         <td class="motivoDerivacion">{{ cliente.motivoDerivacion }} </td>
-                        <td class="fechaReingresoDerivacion">{{ cliente.fechaReingresoDerivacion ? cliente.fechaReingresoDerivacion|date('Y-m-d') : '' }} </td>
+                        <td class="fechaReingresoDerivacion">{{ cliente.fechaReingresoDerivacion ? cliente.fechaReingresoDerivacion|date('d/m/Y') : '' }} </td>
                         <td class="empTrasladoDerivacion">{{ cliente.empTrasladoDerivacion }} </td>
                         <td class="motivoReingresoDerivacion">{{ cliente.motivoReingresoDerivacion }} </td>
                         <td class="dePermiso">{{ cliente.dePermiso }} </td>
-                        <td class="fechaBajaPorPermiso">{{ cliente.fechaBajaPorPermiso ? cliente.fechaBajaPorPermiso|date('Y-m-d') : '' }} </td>
-                        <td class="fechaAltaPorPermiso">{{ cliente.fechaAltaPorPermiso ? cliente.fechaAltaPorPermiso|date('Y-m-d') : '' }} </td>
+                        <td class="fechaBajaPorPermiso">{{ cliente.fechaBajaPorPermiso ? cliente.fechaBajaPorPermiso|date('d/m/Y') : '' }} </td>
+                        <td class="fechaAltaPorPermiso">{{ cliente.fechaAltaPorPermiso ? cliente.fechaAltaPorPermiso|date('d/m/Y') : '' }} </td>
                         <td class="terapiasHabilitadas">{{ cliente.terapiasHabilitadas ? cliente.terapiasHabilitadas|json_encode : '' }} </td>
                         <td class="terapiasNoHabilitadas">{{ cliente.terapiasNoHabilitadas ? cliente.terapiasNoHabilitadas|json_encode : ''  }} </td>
                         <td class="sesionesDisp">{{ cliente.sesionesDisp }} </td>
                         <td class="formNum">{{ cliente.formNum }} </td>
-                        <td class="vtoSesiones">{{ cliente.vtoSesiones ? cliente.vtoSesiones|date('Y-m-d') : ''}} </td>
+                        <td class="vtoSesiones">{{ cliente.vtoSesiones ? cliente.vtoSesiones|date('d/m/Y') : ''}} </td>
                         <td class="mediaSesionView">{{ cliente.mediaSesion }} </td>
                         <td class="dieta">{{ cliente.dieta }} </td>
                         <td class="acciones">

--- a/templates/cliente/novedades.html.twig
+++ b/templates/cliente/novedades.html.twig
@@ -12,11 +12,11 @@
         <div class="row">
             <div class="col">
                 <label for="contrato">Desde</label>
-                <input class="form-control js-datepicker" type="text" id="from" autocomplete="off" name="from" value="{{ from }}">
+                <input class="form-control" type="date" id="from" name="from" value="{{ from }}">
             </div>
             <div class="col">
                 <label for="contrato">Hasta</label>
-                <input class="form-control js-datepicker" type="text" id="to" autocomplete="off" name="to" value="{{ to }}">
+                <input class="form-control" type="date" id="to" name="to" value="{{ to }}">
             </div>
             <div class="col">
                 <label for="estado">Estado</label>
@@ -105,7 +105,7 @@
                         ART
                     {% endif %}
                 </td>
-                <td class="obraSocial">{{ oSociales[cliente.obraSocial] }}</td>
+                <td class="obraSocial"></td>
                 <td><a href="{{ path('cliente_historial', {'id': cliente.id}) }}" class="btn btn-primary btn-sm">HC</a> </td>
             </tr>
             {% if historiasArray[cliente.id] is defined %}

--- a/templates/cliente/show.html.twig
+++ b/templates/cliente/show.html.twig
@@ -33,11 +33,11 @@
             </tr>
             <tr>
                 <th>Fecha de Ingreso</th>
-                <td>{{ cliente.fIngreso ? cliente.fIngreso|date('Y-m-d') : '' }}</td>
+                <td>{{ cliente.fIngreso ? cliente.fIngreso|date('d/m/Y') : '' }}</td>
             </tr>
             <tr>
                 <th>Fecha de Egreso</th>
-                <td>{{ cliente.fEgreso ? cliente.fEgreso|date('Y-m-d') : '' }}</td>
+                <td>{{ cliente.fEgreso ? cliente.fEgreso|date('d/m/Y') : '' }}</td>
             </tr>
             <tr>
                 <th>Motivo de Ingreso</th>

--- a/templates/consumible/enfermeria_planilla.html.twig
+++ b/templates/consumible/enfermeria_planilla.html.twig
@@ -85,7 +85,7 @@
                             </select>
                         </td>#}
                         <td >
-                            <input class="form-control" id='fecha-{{ key }}' type="date" value="{{ dato.fecha ? dato.fecha|date('Y-m-d') : ''}}">
+                            <input class="form-control" id='fecha-{{ key }}' type="date" value="{{ dato.fecha ? dato.fecha|date('d/m/Y') : ''}}">
                         </td>
                         <td >
                             <select class="form-control" id="mes-{{ key }}">
@@ -117,7 +117,7 @@
                             {{ consumibles[dato.consumibleId].tipo ? consumibles[dato.consumibleId].tipo.nombre }}
                         </td>
                         <td class="fecha">
-                            {{ dato.fecha ? dato.fecha|date('Y-m-d') : ''}}
+                            {{ dato.fecha ? dato.fecha|date('d/m/Y') : ''}}
                         </td>
                         <td class="mes">
                             {% for nombre, num in meses %}

--- a/templates/consumible/historico.html.twig
+++ b/templates/consumible/historico.html.twig
@@ -121,7 +121,7 @@
                                 </select>
                             </td>
                             <td >
-                                <input class="form-control" id='fecha-{{ key }}' type="date" value="{{ dato.fecha ? dato.fecha|date('Y-m-d') : ''}}">
+                                <input class="form-control" id='fecha-{{ key }}' type="date" value="{{ dato.fecha ? dato.fecha|date('d/m/Y') : ''}}">
                             </td>
                             <td >
                                 <select class="form-control" id="mes-{{ key }}">
@@ -153,7 +153,7 @@
                                 {{ consumibles[dato.consumibleId].tipo ? consumibles[dato.consumibleId].tipo.nombre }}
                             </td>
                             <td class="fecha">
-                                {{ dato.fecha ? dato.fecha|date('Y-m-d') : ''}}
+                                {{ dato.fecha ? dato.fecha|date('d/m/Y') : ''}}
                             </td>
                             <td class="mes">
                                 {% for nombre, num in meses %}

--- a/templates/consumible/recibos.html.twig
+++ b/templates/consumible/recibos.html.twig
@@ -22,7 +22,7 @@
             {% for recibo in recibos %}
                     <tr>
                         <td >
-                            {{ recibo.fecha ? recibo.fecha|date('Y-m-d') : ''}}
+                            {{ recibo.fecha ? recibo.fecha|date('d/m/Y') : ''}}
                         </td>
                         <td >
                             {{ recibo.count }}

--- a/templates/consumible/show.html.twig
+++ b/templates/consumible/show.html.twig
@@ -23,7 +23,7 @@
                 {% set total = total - dato.cantidad %}
             {% endif %}
             <tr>
-                <td>{{ dato.fecha | date('Y-m-d') }}</td>
+                <td>{{ dato.fecha | date('d/m/Y') }}</td>
                 <td>{{ dato.accion ? 'ingreso' : 'egreso' }}</td>
                 <td style="text-align: right;">{{ dato.cantidad }}</td>
                 <td>{{ pacientes[dato.clienteId] is defined ? pacientes[dato.clienteId] : 'no registrado'}}</td>

--- a/templates/dashboard.html.twig
+++ b/templates/dashboard.html.twig
@@ -30,9 +30,9 @@
                     <div class="modal-body">
                         <div class="form-group columnas-de-dos">
                             <label for="contrato">Desde</label>
-                                <input class="form-control js-datepicker" type="text" id="from" autocomplete="off" value="selecione una fecha">
+                                <input class="form-control" type="date" id="from" name="from">
                             <label for="contrato">Hasta</label>
-                                <input class="form-control js-datepicker" type="text" id="to" autocomplete="off" value="selecione una fecha">
+                                <input class="form-control" type="date" id="to" name="to">
                         </div>
                         <div class="form-group text-right">
                             <button type="button" id="filtrarPorFecha" class="btn btn-primary">Buscar</button>
@@ -225,11 +225,8 @@
                 return 0;
             }
 
-            var FromDateParts = from.split("/");
-            var ToDateParts = to.split("/");
-
-            var headerFrom = new Date(+FromDateParts[2], FromDateParts[1] - 1, +FromDateParts[0]);
-            var headerTo = new Date(+ToDateParts[2], ToDateParts[1] - 1, +ToDateParts[0]);
+            var headerFrom = new Date(from);
+            var headerTo = new Date(to);
 
             if (headerTo < headerFrom) {
                 alert('La fecha desde debe ser mayor a la fecha hasta');

--- a/templates/doctor/agenda.html.twig
+++ b/templates/doctor/agenda.html.twig
@@ -29,7 +29,7 @@
                                 Desde:
                             </div>
                             <div class="col-md-9" style="float: left;">
-                                <input id='from' type="date" class="js-datepicker form-control" value="{{ desde }}">
+                                <input id='from' type="date" class="form-control" value="{{ desde }}">
                             </div>
                         </div>
                         <div class="col-md-6" style="float: left; padding: 0">
@@ -37,7 +37,7 @@
                                 Hasta:
                             </div>
                             <div class="col-md-10" style="float: left;">
-                                <input id='to' type="date" class="js-datepicker form-control" value="{{ hasta }}" data-url="{{ path('doctor_agenda', {'periodo': 'anteriores'}) }}">
+                                <input id='to' type="date" class="form-control" value="{{ hasta }}" data-url="{{ path('doctor_agenda', {'periodo': 'anteriores'}) }}">
                             </div>
                         </div>
                     </div>
@@ -82,8 +82,8 @@
                 {% endif %}
                 <tr class="{% if turno.cliente.MediaSesion %} mediaSesion {% endif %}">
                     <td class="numero">{{ key + 1 }}</td>
-                    <td class="beginAt">{{ turno.beginAt ?  turno.beginAt | date('Y-m-d H:i:s') : '' }}</th>
-                    <td class="endAt">{{ turno.endAt ?  turno.endAt | date('Y-m-d H:i:s') : '' }}</th>
+                    <td class="beginAt">{{ turno.beginAt ?  turno.beginAt | date('d/m/Y H:i:s') : '' }}</th>
+                    <td class="endAt">{{ turno.endAt ?  turno.endAt | date('d/m/Y H:i:s') : '' }}</th>
                     <td class="paciente">{{ turno.cliente.nombre }} {{ turno.cliente.apellido }}</td>
                     <td class="obraSocial">{{ obrasSociales[turno.cliente.obraSocial] }} {% if turno.cliente.MediaSesion %} (Media Sesion) {% endif %}</td>
                     <td class="completado">

--- a/templates/doctor/historias.html.twig
+++ b/templates/doctor/historias.html.twig
@@ -121,7 +121,7 @@
                     <td class="hClinica">{{ cliente.hClinica }}</td>
                     <td class="nombre">{{ cliente.nombre }}</td>
                     <td class="apellido">{{ cliente.apellido }}</td>
-                    <td class="fNacimiento">{{ cliente.fNacimiento ? cliente.fNacimiento|date('Y-m-d') : '' }}</td>
+                    <td class="fNacimiento">{{ cliente.fNacimiento ? cliente.fNacimiento|date('d/m/Y') : '' }}</td>
                     <td class="edad">{{ cliente.edad }}</td>
                     <td class="dni">{{ cliente.dni }}</td>
                     <td class="ultimaEvolucion">
@@ -139,7 +139,7 @@
                     </td>
                     <td class="lowercase email">{{ cliente.email }}</td>
                     <td class="telefono">{{ cliente.telefono }}</td>
-                    <td class="fIngreso">{{ cliente.fIngreso ? cliente.fIngreso|date('Y-m-d') : '' }}</td>
+                    <td class="fIngreso">{{ cliente.fIngreso ? cliente.fIngreso|date('d/m/Y') : '' }}</td>
                     <td class="motivoIng">
                         {% if(cliente.motivoIng == 1) %}
                             Neurologicas
@@ -165,7 +165,7 @@
                             ART
                         {% endif %}
                     </td>
-                    <td class="fEgreso">{{ cliente.fEgreso ? cliente.fEgreso|date('Y-m-d') : '' }}</td>
+                    <td class="fEgreso">{{ cliente.fEgreso ? cliente.fEgreso|date('d/m/Y') : '' }}</td>
                     <td class="motivoEgr">{{ cliente.motivoEgr }}</td>
                     <td class="obraSocial">
                         {{ cliente.obraSocial.nombre }}
@@ -203,19 +203,19 @@
                     <td class="disponibleParaTerapia">{{ cliente.disponibleParaTerapia }} </td>
                     <td class="derivado">{{ cliente.derivado }} </td>
                     <td class="derivadoEn">{{ cliente.derivadoEn }} </td>
-                    <td class="fechaDerivacion">{{ cliente.fechaDerivacion ? cliente.fechaDerivacion|date('Y-m-d') : ''  }} </td>
+                    <td class="fechaDerivacion">{{ cliente.fechaDerivacion ? cliente.fechaDerivacion|date('d/m/Y') : ''  }} </td>
                     <td class="motivoDerivacion">{{ cliente.motivoDerivacion }} </td>
-                    <td class="fechaReingresoDerivacion">{{ cliente.fechaReingresoDerivacion ? cliente.fechaReingresoDerivacion|date('Y-m-d') : '' }} </td>
+                    <td class="fechaReingresoDerivacion">{{ cliente.fechaReingresoDerivacion ? cliente.fechaReingresoDerivacion|date('d/m/Y') : '' }} </td>
                     <td class="empTrasladoDerivacion">{{ cliente.empTrasladoDerivacion }} </td>
                     <td class="motivoReingresoDerivacion">{{ cliente.motivoReingresoDerivacion }} </td>
                     <td class="dePermiso">{{ cliente.dePermiso }} </td>
-                    <td class="fechaBajaPorPermiso">{{ cliente.fechaBajaPorPermiso ? cliente.fechaBajaPorPermiso|date('Y-m-d') : '' }} </td>
-                    <td class="fechaAltaPorPermiso">{{ cliente.fechaAltaPorPermiso ? cliente.fechaAltaPorPermiso|date('Y-m-d') : '' }} </td>
+                    <td class="fechaBajaPorPermiso">{{ cliente.fechaBajaPorPermiso ? cliente.fechaBajaPorPermiso|date('d/m/Y') : '' }} </td>
+                    <td class="fechaAltaPorPermiso">{{ cliente.fechaAltaPorPermiso ? cliente.fechaAltaPorPermiso|date('d/m/Y') : '' }} </td>
                     <td class="terapiasHabilitadas">{{ cliente.terapiasHabilitadas ? cliente.terapiasHabilitadas|json_encode : '' }} </td>
                     <td class="terapiasNoHabilitadas">{{ cliente.terapiasNoHabilitadas ? cliente.terapiasNoHabilitadas|json_encode : ''  }} </td>
                     <td class="sesionesDisp">{{ cliente.sesionesDisp }} </td>
                     <td class="formNum">{{ cliente.formNum }} </td>
-                    <td class="vtoSesiones">{{ cliente.vtoSesiones ? cliente.vtoSesiones|date('Y-m-d') : ''}} </td>
+                    <td class="vtoSesiones">{{ cliente.vtoSesiones ? cliente.vtoSesiones|date('d/m/Y') : ''}} </td>
                     <td class="mediaSesionView">{{ cliente.mediaSesion }} </td>
                     <td class="dieta">{{ cliente.dieta }} </td>
                     <td>

--- a/templates/doctor/index.html.twig
+++ b/templates/doctor/index.html.twig
@@ -98,16 +98,16 @@
                         {{ doctor.matricula }}
                     </td>
                     <td class="vtoMatricula">
-                        {{ doctor.vtoMatricula | date('Y-m-d')}}
+                        {{ doctor.vtoMatricula | date('d/m/Y')}}
                     </td>
                     <td class="libretaSanitaria">
                         {{ doctor.libretaSanitaria }}
                     </td>
                     <td class="emisionLibretaSanitaria">
-                        {{ doctor.emisionLibretaSanitaria | date('Y-m-d')}}
+                        {{ doctor.emisionLibretaSanitaria | date('d/m/Y')}}
                     </td>
                     <td class="vtoLibretaSanitaria">
-                        {{ doctor.vtoLibretaSanitaria | date('Y-m-d') }}
+                        {{ doctor.vtoLibretaSanitaria | date('d/m/Y') }}
                     </td>
                     <td class="posicionEnArchivo">
                         {{ doctor.posicionEnArchivo }}
@@ -116,10 +116,10 @@
                         {{ doctor.email }}
                     </td>
                     <td class="inicioContrato">
-                        {{ doctor.inicioContrato | date('Y-m-d') }}
+                        {{ doctor.inicioContrato | date('d/m/Y') }}
                     </td>
                     <td class="vtoContrato">
-                        {{ doctor.vtoContrato | date('Y-m-d') }}
+                        {{ doctor.vtoContrato | date('d/m/Y') }}
                     </td>
                     <td class="cbu">
                         {{ doctor.cbu }}

--- a/templates/evolucion/index.html.twig
+++ b/templates/evolucion/index.html.twig
@@ -46,7 +46,7 @@
                         <span>Desde:</span>
                     </div>
                     <div class="col-4">
-                        <input class="form-control js-datepicker" type="text" name="from" autocomplete="off" value="{{fechaDesde}}">
+                        <input class="form-control" type="date" name="from" value="{{fechaDesde}}">
                     </div>
                 </div>
                 <div class="row">
@@ -54,7 +54,7 @@
                         <span>Hasta:</span>
                     </div>
                     <div class="col-4">
-                        <input class="form-control js-datepicker" type="text" name="to" autocomplete="off" value="{{fechaHasta}}">
+                        <input class="form-control" type="date" name="to" value="{{fechaHasta}}">
                     </div>
                     <div class="col-2">
                         <button class="btn btn-success"type="submit">buscar</button>
@@ -126,7 +126,7 @@
         {% for evolucion in evolucions %}
             <tr class="tr-link" data-link="{{ path('evolucion_show', {'id': evolucion.id}) }}">
                 <th>{{ evolucion.tipo }}</th>
-                <th>{{ evolucion.fecha ? evolucion.fecha|date('Y-m-d') : '' }}</th>
+                <th>{{ evolucion.fecha ? evolucion.fecha|date('d/m/Y') : '' }}</th>
                 {#<td>{{ evolucion.description|striptags|length > 25 ? evolucion.description|striptags|slice(0, 25) ~ '...' : evolucion.description|striptags }}</td>#}
                 <td>
                     {% if evolucion.adjuntoUrl is not empty %}
@@ -154,10 +154,6 @@
 {% block javascripts %}
     {{ parent() }}
     <script>
-        $('.js-datepicker').datepicker({
-            format: 'dd/mm/yyyy'
-        });
-
         $('.tr-link').click(function() {
             let url = $(this).data('link');
             window.location = url;

--- a/templates/evolucion/show.html.twig
+++ b/templates/evolucion/show.html.twig
@@ -17,7 +17,7 @@
             </tr>
             <tr>
                 <th>Fecha</th>
-                <td>{{ evolucion.fecha ? evolucion.fecha|date('Y-m-d') : '' }}</td>
+                <td>{{ evolucion.fecha ? evolucion.fecha|date('d/m/Y') : '' }}</td>
             </tr>
             <tr>
                 <th>Descripción</th>

--- a/templates/habitacion/_delete_form.html.twig
+++ b/templates/habitacion/_delete_form.html.twig
@@ -1,5 +1,5 @@
 <form method="post" action="{{ path('habitacion_delete', {'id': habitacion.id}) }}" onsubmit="return confirm('Are you sure you want to delete this item?');">
     <input type="hidden" name="_method" value="DELETE">
     <input type="hidden" name="_token" value="{{ csrf_token('delete' ~ habitacion.id) }}">
-    <button class="btn">Delete</button>
+    <button class="btn btn-danger">Delete</button>
 </form>

--- a/templates/liquidaciones/liquidar.html.twig
+++ b/templates/liquidaciones/liquidar.html.twig
@@ -13,7 +13,7 @@
                             Desde:
                         </div>
                         <div class="col-md-10" style="float: left;">
-                            <input id='from' type="date" class="js-datepicker form-control" value="{{ desde }}">
+                            <input id="from" name="from" type="date" class="form-control" value="{{ fechaDesde }}">
                         </div>
                     </div>
                     <div class="col-md-3" style="float: left;">
@@ -21,7 +21,7 @@
                             Hasta:
                         </div>
                         <div class="col-md-10" style="float: left;">
-                            <input id='to' type="date" class="js-datepicker form-control" value="{{ hasta }}">
+                            <input id="to" name="to" type="date" class="form-control" value="{{ fechaHasta }}">
                         </div>
                     </div>
                     {# <div class="col-md-2" style="float: left;">
@@ -79,7 +79,7 @@
                         <td class="fecha">
                             <div>{{ evolucion.paciente.obraSocial.nombre }}</div>
                         </td>
-                        <td class="fecha">{{ evolucion.fecha | date('m/d/Y') }}</td>
+                        <td class="fecha">{{ evolucion.fecha | date('d/m/Y') }}</td>
                         <td class="desc">{{ (evolucion.description|length > 50 ? evolucion.description | striptags |slice(0, 50) ~ '…'   : evolucion.description | striptags )  }}</td>
                         <td><a href="{{ path('evolucion_show', {'id': evolucion.id}) }}">ver</a> </td>
                         <td></td>
@@ -167,7 +167,7 @@
             let obraSocial = $('#obraSocial').val();
             let estado = $('#estado').val();
 
-            url = url + '&desde=' + from + '&hasta=' + to + '&obraSocial=' + obraSocial + '&estado=' + estado;
+            url = url + '&from=' + from + '&to=' + to + '&obraSocial=' + obraSocial + '&estado=' + estado;
 
             window.location.href = url;
         })

--- a/templates/liquidaciones/liquidar_varios.html.twig
+++ b/templates/liquidaciones/liquidar_varios.html.twig
@@ -13,7 +13,7 @@
                             Desde:
                         </div>
                         <div class="col-md-10" style="float: left;">
-                            <input id='from' type="date" class="js-datepicker form-control" value="{{ desde }}">
+                            <input id="from" name="from" type="date" class="form-control" value="{{ fechaDesde }}">
                         </div>
                     </div>
                     <div class="col-md-4" style="float: left;">
@@ -21,7 +21,7 @@
                             Hasta:
                         </div>
                         <div class="col-md-10" style="float: left;">
-                            <input id='to' type="date" class="js-datepicker form-control" value="{{ hasta }}">
+                            <input id="to" name="to" type="date" class="form-control" value="{{ fechaHasta }}">
                         </div>
                     </div>
                 </th>
@@ -69,7 +69,7 @@
                         <tr>
                             <td class="paciente">{{ evolucion.paciente.nombre }} {{ evolucion.paciente.apellido }}</td>
                             <td class="fecha">{{ evolucion.paciente.obraSocial.nombre }}</td>
-                            <td class="fecha">{{ evolucion.fecha | date('m/d/Y') }}</td>
+                            <td class="fecha">{{ evolucion.fecha | date('d/m/Y') }}</td>
                             <td class="desc">{{ (evolucion.description|length > 50 ? evolucion.description|slice(0, 50) ~ '…' : evolucion.description)  }}</td>
                             <td><a href="{{ path('evolucion_show', {'id': evolucion.id}) }}">ver</a> </td>
                         </tr>
@@ -147,7 +147,7 @@
             let obraSocial = $('#obraSocial').val();
             let completados = $('#completados').val();
 
-            url = url + '&desde=' + from + '&hasta=' + to + '&obraSocial=' + obraSocial + '&completados=' + completados;
+            url = url + '&from=' + from + '&to=' + to + '&obraSocial=' + obraSocial + '&completados=' + completados;
 
             window.location.href = url;
         })

--- a/templates/liquidaciones/profesionales.html.twig
+++ b/templates/liquidaciones/profesionales.html.twig
@@ -61,10 +61,10 @@
                     {#<a href="{{ asset('uploads/firmas/' ~ doctor.firma) }}" target="_blank">Ver firma digital</a>#}
                 </td>
                 <td>
-                    {{ doctor.inicioContrato | date('Y-m-d') }}
+                    {{ doctor.inicioContrato | date('d/m/Y') }}
                 </td>
                 <td>
-                    {{ doctor.vtoContrato | date('Y-m-d') }}
+                    {{ doctor.vtoContrato | date('d/m/Y') }}
                 </td>
                 <td class="">
                     {{ doctor.cbu }}

--- a/templates/notas_historia_clinica/index.html.twig
+++ b/templates/notas_historia_clinica/index.html.twig
@@ -19,7 +19,7 @@
             <tr>
                 <td>{{ notas_historia_clinica.id }}</td>
                 <td>{{ notas_historia_clinica.text }}</td>
-                <td>{{ notas_historia_clinica.fecha ? notas_historia_clinica.fecha|date('Y-m-d') : '' }}</td>
+                <td>{{ notas_historia_clinica.fecha ? notas_historia_clinica.fecha|date('d/m/Y') : '' }}</td>
                 <td>
                     <a href="{{ path('notas_historia_clinica_show', {'id': notas_historia_clinica.id}) }}">show</a>
                     <a href="{{ path('notas_historia_clinica_edit', {'id': notas_historia_clinica.id}) }}">edit</a>

--- a/templates/notas_historia_clinica/show.html.twig
+++ b/templates/notas_historia_clinica/show.html.twig
@@ -17,7 +17,7 @@
             </tr>
             <tr>
                 <th>Fecha</th>
-                <td>{{ notas_historia_clinica.fecha ? notas_historia_clinica.fecha|date('Y-m-d') : '' }}</td>
+                <td>{{ notas_historia_clinica.fecha ? notas_historia_clinica.fecha|date('d/m/Y') : '' }}</td>
             </tr>
         </tbody>
     </table>

--- a/templates/prescripcion/show.html.twig
+++ b/templates/prescripcion/show.html.twig
@@ -17,7 +17,7 @@
             </tr>
             <tr>
                 <th>Fecha</th>
-                <td>{{ prescripcion.fecha ? prescripcion.fecha|date('Y-m-d') : '' }}</td>
+                <td>{{ prescripcion.fecha ? prescripcion.fecha|date('d/m/Y') : '' }}</td>
             </tr>
         </tbody>
     </table>


### PR DESCRIPTION
- Se normaliza fechas del lado del cliente en formato d/m/Y.
- Se quita la utilizacion de la libreria js-datepicker
- Se coloca por defecto fecha desde y hasta en las secciones que poseen esos filtros (para bajar peso de la consulta al inicio) y se genera un new date time con el tiempo ya seteado antes de cada query.